### PR TITLE
 Fixed ownerhip issues

### DIFF
--- a/icey/doc/source/api_entities.md
+++ b/icey/doc/source/api_entities.md
@@ -14,9 +14,6 @@ All the ROS entities (subscriptions, publishers, timers etc.) are wrapped so tha
 ```{doxygenstruct} icey::PublisherStream
 ```
 
-```{doxygenstruct} icey::ServiceStream
-```
-
 ```{doxygenstruct} icey::ServiceClient
 ```
 

--- a/icey/test/entities_async_await_test.cpp
+++ b/icey/test/entities_async_await_test.cpp
@@ -217,7 +217,7 @@ TEST_F(AsyncAwaitTwoNodeTest, ServiceTimeoutTest) {
     EXPECT_TRUE(result1.has_error());
     EXPECT_EQ(result1.error(), "TIMEOUT");
     /// Expect there are no pending requests in case of timeout: A call to prune must return 0
-    EXPECT_EQ(client1.client->prune_pending_requests(), 0);
+    EXPECT_EQ(client1.client()->prune_pending_requests(), 0);
 
     /// Send the first request but do not await it
     icey::Promise<Response, std::string> response_future1 = client1.call(request, 40ms);
@@ -228,7 +228,7 @@ TEST_F(AsyncAwaitTwoNodeTest, ServiceTimeoutTest) {
     EXPECT_TRUE((co_await response_future2).has_value());
     EXPECT_TRUE((co_await response_future1).has_value());
 
-    EXPECT_EQ(client1.client->prune_pending_requests(), 0);
+    EXPECT_EQ(client1.client()->prune_pending_requests(), 0);
 
     async_completed = true;
     co_return 0;

--- a/icey/test/entities_test.cpp
+++ b/icey/test/entities_test.cpp
@@ -272,3 +272,20 @@ TEST_F(NodeTest, OneOffTimerTest) {
   spin(300ms);
   EXPECT_EQ(timer_ticked, 1);
 }
+
+/*TEST_F(TwoNodesFixture, ServiceClientTest) {
+  {
+    auto service_client =
+      receiver_->icey().create_client<ExampleService>("icey_test_service");
+    
+    EXPECT_TRUE(receiver_->get_service_names_and_types().contains("icey_test_service"));
+    /// Test that copying the client works and that also making an request through a client copy works after this  client copy was destroyed
+    {
+      auto client2 = service_client;
+      
+    }
+    spin(1500ms);
+  }
+  /// Assert the client was destroyed
+  EXPECT_TRUE(receiver_->get_service_names_and_types().empty());  
+}*/


### PR DESCRIPTION
- Classes capturing the this-pointer should be non-copyable to prevent use-after-free bugs. 
- After they are non-copyable, users can't store them in the node-class, so a PIMPL-wrapper became necessary for the service client.
- PIMPL-wrappers should generally mirror the impl-API, because there is no reason for arbitrary deviations. For this reason I added the promise-based functions into the impl-classes and the callback-based functions into the actual non-impl classes.
- I decided on ownership semantics of the service client: No bookkeeping is provided for it since having a client without a handle to it is useless. PIMPL however is still useful to avoid users having to use shared pointers everywhere.
- Contains also some cleanups: including less headers, not using custom but instead standard weak pointer
