### PR TITLE
Fix for coroutines without suspension points

### DIFF
--- a/icey/CMakeLists.txt
+++ b/icey/CMakeLists.txt
@@ -45,6 +45,7 @@ if(BUILD_TESTING)
     test/context_test.cpp
     test/promise_test.cpp
     test/nested_coroutines.cpp
+    test/promise_async_await_test.cpp
   )  
   target_link_libraries(test_main fmt::fmt)
   set_tests_properties(test_main PROPERTIES TIMEOUT 180)

--- a/icey/include/icey/impl/promise.hpp
+++ b/icey/include/icey/impl/promise.hpp
@@ -273,7 +273,7 @@ protected:
   State state_;
 
   /// Whether the promise was resolved or rejected.
-  std::atomic_bool is_done_;
+  std::atomic_bool is_done_{false};
 
   /// A synchronous cancellation function. It unregisters for example a ROS callback so that it is
   /// not going to be called anymore. Such cancellations are needed because the ROS callback

--- a/icey/include/icey/impl/promise.hpp
+++ b/icey/include/icey/impl/promise.hpp
@@ -261,9 +261,9 @@ public:
 
   /// We do not use structured concurrency approach, we want to start the coroutine directly.
   std::suspend_never initial_suspend() const noexcept { return {}; }
-  /// Suspend at final suspend and let the returned `icey::Promise` wrapper own/destroy the
-  /// coroutine frame.
-  std::suspend_always final_suspend() const noexcept { return {}; }
+  /// We do not suspend at the final suspend point, but continue so that the coroutine state is
+  /// destructed automaticall when the coroutine is finished.
+  std::suspend_never final_suspend() const noexcept { return {}; }
 
   /// Set the cancellation function that is called in the destructor if this promise has_none().
   void set_cancel(Cancel cancel) { cancel_ = cancel; }

--- a/icey/test/entities_async_await_test.cpp
+++ b/icey/test/entities_async_await_test.cpp
@@ -22,7 +22,7 @@ struct AsyncAwaitNodeTest : NodeTest {
 };
 
 TEST_F(AsyncAwaitNodeTest, ParameterTest) {
-  [this]() -> icey::Stream<int> {
+  [this]() -> icey::Promise<int> {
     auto string_param = node_->icey().declare_parameter<std::string>("icey_test_my_param", "hello");
 
     EXPECT_TRUE(node_->has_parameter("icey_test_my_param"));
@@ -39,7 +39,7 @@ TEST_F(AsyncAwaitNodeTest, ParameterTest) {
 }
 
 TEST_F(AsyncAwaitNodeTest, TimerTest) {
-  const auto l = [this]() -> icey::Stream<int> {
+  const auto l = [this]() -> icey::Promise<int> {
     size_t timer_ticked{0};
     auto timer = node_->icey().create_timer(100ms);
     EXPECT_EQ(timer_ticked, 0);
@@ -69,7 +69,7 @@ struct AsyncAwaitTwoNodeTest : TwoNodesFixture {
 };
 
 TEST_F(AsyncAwaitTwoNodeTest, PubSubTest) {
-  const auto l = [this]() -> icey::Stream<int> {
+  const auto l = [this]() -> icey::Promise<int> {
     sender_->icey()
         .create_timer(100ms)
         .then([](size_t ticks) {
@@ -96,12 +96,12 @@ TEST_F(AsyncAwaitTwoNodeTest, PubSubTest) {
   };
   l();  /// Temporary lifetime extention is unaware of coroutines and would destroy the lambda after
         /// first suspend if we would not assign a name l to it
-  spin(1100ms);
+  spin(1500ms);
   ASSERT_TRUE(async_completed);
 }
 
 TEST_F(AsyncAwaitTwoNodeTest, PubSubTest2) {
-  const auto l = [this]() -> icey::Stream<int> {
+  const auto l = [this]() -> icey::Promise<int> {
     std::size_t received_cnt{0};
 
     receiver_->icey()
@@ -136,7 +136,7 @@ TEST_F(AsyncAwaitTwoNodeTest, PubSubTest2) {
 }
 
 TEST_F(AsyncAwaitTwoNodeTest, ServiceTest) {
-  const auto l = [this]() -> icey::Stream<int> {
+  const auto l = [this]() -> icey::Promise<int> {
     // The response we are going to receive from the service call:
     using Response = ExampleService::Response::SharedPtr;
 
@@ -191,7 +191,7 @@ TEST_F(AsyncAwaitTwoNodeTest, ServiceTest) {
 // It also tests whether we can make multiple calls to a service before awaiting them all and after
 // awaiting, we receive all of them
 TEST_F(AsyncAwaitTwoNodeTest, ServiceTimeoutTest) {
-  const auto l = [this]() -> icey::Stream<int> {
+  const auto l = [this]() -> icey::Promise<int> {
     // The response we are going to receive from the service call:
     using Response = ExampleService::Response::SharedPtr;
 
@@ -239,7 +239,7 @@ TEST_F(AsyncAwaitTwoNodeTest, ServiceTimeoutTest) {
 }
 
 TEST_F(AsyncAwaitTwoNodeTest, TFAsyncLookupTest) {
-  const auto l = [this]() -> icey::Stream<int> {
+  const auto l = [this]() -> icey::Promise<int> {
     const icey::Time base_time{1700000000s};
 
     sender_->icey()

--- a/icey/test/promise_async_await_test.cpp
+++ b/icey/test/promise_async_await_test.cpp
@@ -1,0 +1,142 @@
+/// Copyright © 2025 Technische Hochschule Augsburg
+/// All rights reserved.
+/// Author: Ivo Ivanov
+/// This software is licensed under the Apache License, Version 2.0.
+
+#include <gtest/gtest.h>
+
+#include <deque>
+#include <functional>
+#include <icey/impl/promise.hpp>
+#include <string>
+#include <vector>
+
+namespace {
+
+icey::Promise<int> immediate_plain() { co_return 7; }
+
+icey::Promise<int, std::string> immediate_result_ok() {
+  co_return icey::impl::PromiseState<int, std::string>{
+      icey::Result<int, std::string>(icey::Ok<int>(5))};
+}
+
+icey::Promise<int, std::string> immediate_result_err() {
+  co_return icey::impl::PromiseState<int, std::string>{
+      icey::Result<int, std::string>(icey::Err<std::string>("immediate_error"))};
+}
+
+struct InlineEventLoop {
+  std::deque<std::function<void()>> events;
+  void dispatch(std::function<void()> f) { events.push_back(std::move(f)); }
+  void run_all() {
+    while (!events.empty()) {
+      auto f = std::move(events.front());
+      events.pop_front();
+      f();
+    }
+  }
+};
+
+icey::impl::Promise<int> deferred_plain(InlineEventLoop &loop, int value) {
+  return {[&loop, value](auto &promise) { loop.dispatch([&promise, value]() { promise.resolve(value); }); }};
+}
+
+icey::impl::Promise<int, std::string> deferred_result(InlineEventLoop &loop, bool fail) {
+  return {[&loop, fail](auto &promise) {
+    loop.dispatch([&promise, fail]() {
+      if (fail) {
+        promise.reject("inner_error");
+      } else {
+        promise.resolve(40);
+      }
+    });
+  }};
+}
+
+icey::Promise<void> nested_plain_log(InlineEventLoop &loop, std::vector<std::string> &events) {
+  events.emplace_back("outer_start");
+  int value = co_await deferred_plain(loop, 41);
+  events.emplace_back(std::to_string(value + 1));
+  co_return;
+}
+
+icey::Promise<void> nested_result_log(InlineEventLoop &loop, bool fail,
+                                      std::vector<std::string> &events) {
+  events.emplace_back("outer_start");
+  auto result = co_await deferred_result(loop, fail);
+  if (result.has_value()) {
+    events.emplace_back(std::to_string(result.value() + 2));
+  } else {
+    events.emplace_back(result.error());
+  }
+  co_return;
+}
+
+icey::Promise<void> cancellation_in_scope(bool &cancelled) {
+  auto pending = icey::impl::Promise<int, std::string>([&cancelled](auto &promise) {
+    promise.set_cancel([&cancelled](auto &) { cancelled = true; });
+  });
+  (void)pending;
+  co_return;
+}
+
+}  // namespace
+
+TEST(IceyPromiseAsyncAwaitTest, AwaitImmediateCoReturnWithoutErrorType) {
+  bool completed = false;
+
+  [&]() -> icey::Promise<void> {
+    (void)co_await immediate_plain();
+    completed = true;
+    co_return;
+  }();
+
+  /// Documented current behavior: awaiting a synchronously completed coroutine does not continue.
+  EXPECT_FALSE(completed);
+}
+
+TEST(IceyPromiseAsyncAwaitTest, AwaitImmediateCoReturnWithErrorType) {
+  bool completed = false;
+
+  [&]() -> icey::Promise<void> {
+    (void)co_await immediate_result_ok();
+    (void)co_await immediate_result_err();
+    completed = true;
+    co_return;
+  }();
+
+  /// Documented current behavior: awaiting a synchronously completed coroutine does not continue.
+  EXPECT_FALSE(completed);
+}
+
+TEST(IceyPromiseAsyncAwaitTest, NestedCoroutinesWithoutErrorType) {
+  InlineEventLoop loop;
+  std::vector<std::string> events;
+  nested_plain_log(loop, events);
+  loop.run_all();
+  std::vector<std::string> expected{"outer_start", "42"};
+  EXPECT_EQ(events, expected);
+}
+
+TEST(IceyPromiseAsyncAwaitTest, NestedCoroutinesWithErrorType) {
+  InlineEventLoop loop;
+  std::vector<std::string> events_ok;
+  std::vector<std::string> events_err;
+  nested_result_log(loop, false, events_ok);
+  nested_result_log(loop, true, events_err);
+  loop.run_all();
+  std::vector<std::string> expected_ok{"outer_start", "42"};
+  std::vector<std::string> expected_err{"outer_start", "inner_error"};
+  EXPECT_EQ(events_ok, expected_ok);
+  EXPECT_EQ(events_err, expected_err);
+}
+
+TEST(IceyPromiseAsyncAwaitTest, CancellationInUnawaitedCoroutineScopeIsNotTriggered) {
+  bool cancelled = false;
+
+  cancellation_in_scope(cancelled);
+
+  /// Documented current behavior: without coroutine frame destruction, local promise cancellation
+  /// callbacks are not reached.
+  EXPECT_FALSE(cancelled);
+}

--- a/icey/test/promise_async_await_test.cpp
+++ b/icey/test/promise_async_await_test.cpp
@@ -118,23 +118,26 @@ TEST(IceyPromiseAsyncAwaitTest, AwaitImmediateCoReturnWithErrorType) {
 TEST(IceyPromiseAsyncAwaitTest, NestedCoroutinesWithoutErrorType) {
   InlineEventLoop loop;
   std::vector<std::string> events;
-  nested_plain_log(loop, events);
+  auto nested = nested_plain_log(loop, events);
   loop.run_all();
   std::vector<std::string> expected{"outer_start", "42"};
   EXPECT_EQ(events, expected);
+  (void)nested;
 }
 
 TEST(IceyPromiseAsyncAwaitTest, NestedCoroutinesWithErrorType) {
   InlineEventLoop loop;
   std::vector<std::string> events_ok;
   std::vector<std::string> events_err;
-  nested_result_log(loop, false, events_ok);
-  nested_result_log(loop, true, events_err);
+  auto nested_ok = nested_result_log(loop, false, events_ok);
+  auto nested_err = nested_result_log(loop, true, events_err);
   loop.run_all();
   std::vector<std::string> expected_ok{"outer_start", "42"};
   std::vector<std::string> expected_err{"outer_start", "inner_error"};
   EXPECT_EQ(events_ok, expected_ok);
   EXPECT_EQ(events_err, expected_err);
+  (void)nested_ok;
+  (void)nested_err;
 }
 
 TEST(IceyPromiseAsyncAwaitTest, CancellationInUnawaitedCoroutineScopeIsNotTriggered) {
@@ -142,7 +145,5 @@ TEST(IceyPromiseAsyncAwaitTest, CancellationInUnawaitedCoroutineScopeIsNotTrigge
 
   cancellation_in_scope(cancelled);
 
-  /// Documented current behavior: without coroutine frame destruction, local promise cancellation
-  /// callbacks are not reached.
   EXPECT_FALSE(cancelled);
 }

--- a/icey/test/promise_async_await_test.cpp
+++ b/icey/test/promise_async_await_test.cpp
@@ -84,29 +84,35 @@ icey::Promise<void> cancellation_in_scope(bool &cancelled) {
 
 TEST(IceyPromiseAsyncAwaitTest, AwaitImmediateCoReturnWithoutErrorType) {
   bool completed = false;
+  int value = 0;
 
   [&]() -> icey::Promise<void> {
-    (void)co_await immediate_plain();
+    value = co_await immediate_plain();
     completed = true;
     co_return;
   }();
 
-  /// Documented current behavior: awaiting a synchronously completed coroutine does not continue.
-  EXPECT_FALSE(completed);
+  EXPECT_TRUE(completed);
+  EXPECT_EQ(value, 7);
 }
 
 TEST(IceyPromiseAsyncAwaitTest, AwaitImmediateCoReturnWithErrorType) {
   bool completed = false;
+  icey::Result<int, std::string> ok_result{icey::Err<std::string>("unset")};
+  icey::Result<int, std::string> err_result{icey::Err<std::string>("unset")};
 
   [&]() -> icey::Promise<void> {
-    (void)co_await immediate_result_ok();
-    (void)co_await immediate_result_err();
+    ok_result = co_await immediate_result_ok();
+    err_result = co_await immediate_result_err();
     completed = true;
     co_return;
   }();
 
-  /// Documented current behavior: awaiting a synchronously completed coroutine does not continue.
-  EXPECT_FALSE(completed);
+  EXPECT_TRUE(completed);
+  EXPECT_TRUE(ok_result.has_value());
+  EXPECT_EQ(ok_result.value(), 5);
+  EXPECT_TRUE(err_result.has_error());
+  EXPECT_EQ(err_result.error(), "immediate_error");
 }
 
 TEST(IceyPromiseAsyncAwaitTest, NestedCoroutinesWithoutErrorType) {


### PR DESCRIPTION
This fixes that coroutines awaiting coroutines with a single co_return and no suspension points would never finish (https://github.com/iv461/icey/issues/16#issue-3927408084).
Also adds unit tests.

Since I've changed the coroutine state destruction logic, I've profiled again for memory leaks: 

<img width="1337" height="376" alt="grafik" src="https://github.com/user-attachments/assets/bf9e29da-ff5a-44b3-8fbe-d18473e4882f" />

<img width="1329" height="497" alt="grafik" src="https://github.com/user-attachments/assets/f3cc5cc7-5d64-44b1-855b-ac953d2b8b3d" />

<img width="1329" height="919" alt="grafik" src="https://github.com/user-attachments/assets/9a5a52ee-7eae-4a07-a411-01c616e391e9" />

<img width="1329" height="908" alt="grafik" src="https://github.com/user-attachments/assets/a3623389-5517-40f2-9240-56c591a56886" />

In two test runs, one short (14s) and one longer (1.5m)  the results remain the same, indicating no memory leaks of the coroutine state.

